### PR TITLE
Disable manual carousel scrolling

### DIFF
--- a/script.js
+++ b/script.js
@@ -755,6 +755,10 @@ function setupArrows(){
   prev.addEventListener("click", ()=> row.scrollBy({ left: -Math.max(400, row.clientWidth * 0.8), behavior: "smooth" }));
   next.addEventListener("click", ()=> row.scrollBy({ left:  Math.max(400, row.clientWidth * 0.8), behavior: "smooth" }));
 
+  ["wheel", "touchmove"].forEach(evt => {
+    row.addEventListener(evt, e => e.preventDefault(), { passive: false });
+  });
+
   window.addEventListener("resize", recalc);
   new ResizeObserver(recalc).observe(row);
   new MutationObserver(recalc).observe(row, { childList: true });
@@ -765,8 +769,8 @@ function setupKeyboardNav(){
   const row = document.querySelector(`.carousel[data-row="recientes"]`);
   if(!row) return;
   row.addEventListener("keydown",(e)=>{
-    if(e.key==="ArrowRight") row.scrollBy({ left: 200, behavior: "smooth" });
-    if(e.key==="ArrowLeft")  row.scrollBy({ left: -200, behavior: "smooth" });
+    if(e.key==="ArrowRight"){ e.preventDefault(); row.scrollBy({ left: 200, behavior: "smooth" }); }
+    if(e.key==="ArrowLeft") { e.preventDefault(); row.scrollBy({ left: -200, behavior: "smooth" }); }
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -274,8 +274,7 @@ body.modal-open > *:not(.tw-modal) { filter: blur(4px); }
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  overflow-x: auto;
-  overflow-y: hidden;
+  overflow: hidden;
   align-content: flex-start;
   padding-bottom: 8px;
   scroll-snap-type: x mandatory;


### PR DESCRIPTION
## Summary
- Hide scrollbars and overflow on the carousel
- Prevent manual wheel/touch scrolling; keep arrow navigation and keyboard support

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6add9574c832cad83d2d0f087b0dd